### PR TITLE
Fixed mnemonic error

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,7 +1,6 @@
 [
     {
         "caption": "Unicode Characters",
-        "mnemonic": "f",
         "id": "unicode_character_insert",
         "children":
         [


### PR DESCRIPTION
Когда я открываю контекстное меню, в консоли появляется ошибка:

> warning: mnemonic f not found in menu caption Unicode Characters

В отличие от Menu Bar в контекстное меню Sublime Text не требуется добавлять mnemonics. Cм., как реализовано контекстное меню в других плагинах. 

В [статье](http://onedev.net/post/587) также исправьте ошибку.

Спасибо.
